### PR TITLE
switched the height, width variables order to match code

### DIFF
--- a/LucidDreamer_Gaussian_colab.ipynb
+++ b/LucidDreamer_Gaussian_colab.ipynb
@@ -30,7 +30,7 @@
         "!apt -y install -qq aria2\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/camenduru/ZoeDepth/resolve/main/ZoeD_M12_N.pt -d /root/.cache/torch/hub/checkpoints -o ZoeD_M12_N.pt\n",
         "\n",
-        "!sed -i 's/\\(new_height, new_width\\)/int(new_height), int(new_width)/g' /content/LucidDreamer-Gaussian/ZoeDepth/zoedepth/models/base_models/midas.py\n",
+        "!sed -i 's/\\(new_width, new_height\\)/int(new_width), int(new_height)/g' /content/LucidDreamer-Gaussian/ZoeDepth/zoedepth/models/base_models/midas.py\n",
         "\n",
         "import torch\n",
         "torch.hub.load('./ZoeDepth', 'ZoeD_N', source='local', pretrained=True).to('cuda')\n",


### PR DESCRIPTION
In the sed fix - previous order was flipped from what's in the code